### PR TITLE
55 user iters for merging instead of arrays

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ rand_core = "0.6.0"
 bevy_math = "0.15.1"
 flagset = "0.4.5"
 macros = { path = "macros" }
+bumpalo = {version = "3.17.0", features = ["default", "collections"]}
 
 [dev-dependencies]
 criterion = "0.5.1"


### PR DESCRIPTION
Pro: now we can pass in more than just arrays. Very nice.
Cons: weighted merging (currently unused but useful to have) now needs to allocate.